### PR TITLE
Etend à 2 ans la durée d'affichage du graphique comptage par semaine

### DIFF
--- a/prepare.js
+++ b/prepare.js
@@ -175,7 +175,8 @@ const prepare = (ids, details, metadata, counter) => {
   const now = DateTime.local().set(dayFmt);
   const oneDay = now.minus({ day: 2 }).toISO();
   const oneMonth = now.minus({ month: 1 }).toISO();
-  const oneYear = now.minus({ year: 1 }).toISO();
+  const twoYear = now.minus({ year: 2 }).toISO();
+  
 
   return {
     title: counter,
@@ -191,7 +192,7 @@ const prepare = (ids, details, metadata, counter) => {
     week_record: record(sorted, weekFmt),
     month: group(sorted, dayFmt, oneMonth),
     year: group(sorted, weekFmt, null),
-    year_daily: group(sorted, dayFmt, oneYear),
+    year_daily: group(sorted, dayFmt, twoYear),
   };
 };
 


### PR DESCRIPTION
Le nouveau jeu de donnée permet de remonter sur 2ans: afficher 2 ans du graphique comptage par semaine permet de comparer une semaine d'une année à la même l'an précédent.