### PR TITLE
Corrige le calcul de la date max pour chaque compteur

### DIFF
--- a/data/read_data.ts
+++ b/data/read_data.ts
@@ -84,7 +84,7 @@ export async function counts(): Promise<{
           const date = DateTime.fromISO(data['date']);
 
           counters[id].minDate = _.min([counters[id].minDate, date]);
-          counters[id].maxDate = _.max([counters[id].minDate, date]);
+          counters[id].maxDate = _.max([counters[id].maxDate, date]);
 
           counters[id].total += count;
 


### PR DESCRIPTION
Tentative de correction de #11 

Après correction du calcul de la durée, les moyennes sur la vie de chaque compteur redeviennent raisonnables:
<img width="399" alt="image" src="https://github.com/velo-cite/compteurs-velo/assets/124528680/a3d6cedb-ecf7-4c66-bb3c-25accee3a7b7">
