### PR TITLE
Fix bxmetro url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn install
 
 # Download counters data
 RUN mkdir public \
- && wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B" -O public/compteurs.csv
+ && wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=;" -O public/compteurs.csv
 
 # Rename headers
 ADD scripts/rename-header-compteurs-csv.sh scripts/

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@ import-metadata-paris:
 	- wget "https://parisdata.opendatasoft.com/api/v2/catalog/datasets/comptage-velo-compteurs/exports/csv" -O public/metadata.csv
 
 import-compteurs-bordeaux-old:
-	- wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_captv_p_histo_heure/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&csv_separator=%3B&refine=type%3A%22BOUCLE%22" -O public/compteurs-old.csv
+	- wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_captv_p_histo_heure/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&csv_separator=;&refine=type%3A%22BOUCLE%22" -O public/compteurs-old.csv
 	- ./scripts/rename-header-compteurs-csv.sh
 
 import-compteurs-bordeaux:
-	-# wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&qv1=(datedebut%3A%5B2024-06-08T22%3A00%3A00Z%20TO%202024-06-11T21%3A59%3A59Z%5D)&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B" -O public/compteurs.csv
-	- wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B" -O public/compteurs.csv
+	-# wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&qv1=(datedebut%3A%5B2024-06-08T22%3A00%3A00Z%20TO%202024-06-11T21%3A59%3A59Z%5D)&timezone=Europe%2FBerlin&use_labels=true&delimiter=;" -O public/compteurs.csv
+	- wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=;" -O public/compteurs.csv
 	- ./scripts/rename-header-compteurs-csv.sh
 
 import-metadata-bordeaux: 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Des capteur (« boucles ») sont installées au sein du goudron un peu partout
 Contrairement aux données de Paris, un seul jeu de données est disponible. La liste unique des compteurs a été réalisée à la main et devra être complétée à l'avenir si de nouveaux compteurs sont ajoutés.
 
 Le jeu de données contient les données de comptage (une mesure par heure et par compteur) :
-`wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=%3B" -O public/compteurs.csv`
+`wget "https://opendata.bordeaux-metropole.fr/api/explore/v2.1/catalog/datasets/pc_velo_p/exports/csv?lang=fr&timezone=Europe%2FBerlin&use_labels=true&delimiter=;" -O public/compteurs.csv`
 
 L'import est scripté via une commande make : `make import-compteurs-bordeaux`
 


### PR DESCRIPTION
Le format d'url de l'opendata n'accepte plus `%3B` pour `;` pour le champ `delimiter`
Proposition de remplacer `%3B` par `;`

A tester